### PR TITLE
Admin registration db bug fixed

### DIFF
--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -24,7 +24,7 @@ router.post("/signup", async (req, res) => {
   if (user) {
     res.status(403).json({ message: "Admin already exists" });
   } else {
-    const newUser = new User({ username, password });
+    const newUser = new Admin({ username, password });
     await newUser.save();
     const token = jwt.sign({ username, role: "admin" }, SECRET, {
       expiresIn: "1h",


### PR DESCRIPTION
While Registring as an admin, the data is saved in collection User intead of collection Admin because the in signup post request we are creating the new User intead of new Admin.

file: server/routes/admin.js  //line no. 27

previous code:  const newUser = new User({ username, password });

New Code :  const newUser = new Admin({ username, password });